### PR TITLE
Some tweaks to example

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -118,6 +118,7 @@ fn main() {
 
                 ui.show_demo_window(&mut true);
 
+                platform.prepare_render(&ui, &windowed_context.window());
                 let draw_data = ui.render();
                 imgui_renderer.render(&gl, &draw_data);
                 windowed_context.swap_buffers().unwrap();

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,11 +1,12 @@
+use std::time::Instant;
+
 use glow::*;
+use glutin::event::{Event, WindowEvent};
+use glutin::event_loop::ControlFlow;
 
 use imgui::im_str;
-use imgui_winit_support::{HiDpiMode, WinitPlatform};
-
 use imgui_glow_renderer::Renderer;
-
-use std::time::Instant;
+use imgui_winit_support::{HiDpiMode, WinitPlatform};
 
 fn main() {
     let event_loop = glutin::event_loop::EventLoop::new();
@@ -16,6 +17,7 @@ fn main() {
         .unwrap();
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
+    // Create glow Context
     let gl = unsafe {
         let context = glow::Context::from_loader_function(|s| {
             windowed_context.get_proc_address(s) as *const _
@@ -23,13 +25,8 @@ fn main() {
         context
     };
 
-    use glutin::event::{Event, WindowEvent};
-    use glutin::event_loop::ControlFlow;
-
-    let mut changeable = 0.01;
+    // Used to update imgui's timer in main loop
     let mut last_frame = Instant::now();
-
-    let scale_factor = windowed_context.window().scale_factor() as f32;
 
     // Create and configure imgui context
     let mut imgui = imgui::Context::create();
@@ -46,6 +43,8 @@ fn main() {
     );
 
     // Configure font (using built-in fixed size bitmap font)
+    let scale_factor = windowed_context.window().scale_factor() as f32;
+
     let font_size = 13.0 * scale_factor;
     imgui
         .fonts()
@@ -68,6 +67,7 @@ fn main() {
     let imgui_renderer = Renderer::new(&gl, &mut imgui);
 
     // Attributes for demo app
+    let mut changeable = 0.01;
     let mut modifiable_string = imgui::ImString::new("");
     let mut mod_color = [0.0, 0.0, 0.0, 0.0];
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,22 +1,22 @@
 use glow::*;
 
-use imgui::{im_str};
+use imgui::im_str;
 use imgui_winit_support::{HiDpiMode, WinitPlatform};
-
 
 use imgui_glow_renderer::Renderer;
 
 use std::time::Instant;
 
 fn main() {
-
     let event_loop = glutin::event_loop::EventLoop::new();
     let wb = glutin::window::WindowBuilder::new().with_title("A fantastic window!");
 
-    let windowed_context = glutin::ContextBuilder::new().build_windowed(wb, &event_loop).unwrap();
-    let windowed_context= unsafe { windowed_context.make_current().unwrap() };
+    let windowed_context = glutin::ContextBuilder::new()
+        .build_windowed(wb, &event_loop)
+        .unwrap();
+    let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
-    let gl =   unsafe {
+    let gl = unsafe {
         let context = glow::Context::from_loader_function(|s| {
             windowed_context.get_proc_address(s) as *const _
         });
@@ -24,110 +24,113 @@ fn main() {
     };
 
     unsafe {
-
         use glutin::event::{Event, WindowEvent};
         use glutin::event_loop::ControlFlow;
 
         let mut changeable = 0.01;
         let mut last_frame = Instant::now();
 
-   
         let scale_factor = windowed_context.window().scale_factor() as f32;
         let mut imgui = imgui::Context::create();
         imgui.set_ini_filename(None);
-    
+
         let mut platform = WinitPlatform::init(&mut imgui);
-        platform.attach_window(imgui.io_mut(), windowed_context.window(),   HiDpiMode::Default);
+        platform.attach_window(
+            imgui.io_mut(),
+            windowed_context.window(),
+            HiDpiMode::Default,
+        );
 
         let font_size = 13.0 * scale_factor;
-        imgui.fonts().add_font(&[
-            imgui::FontSource::DefaultFontData{
-                config : Some(imgui::FontConfig{
-                        size_pixels : font_size,
-                        .. imgui::FontConfig::default()
+        imgui
+            .fonts()
+            .add_font(&[imgui::FontSource::DefaultFontData {
+                config: Some(imgui::FontConfig {
+                    size_pixels: font_size,
+                    ..imgui::FontConfig::default()
                 }),
-            }
-        ]);
+            }]);
 
         imgui.io_mut().font_global_scale = (1.0 / scale_factor) as f32;
         let mut style = imgui.style_mut().clone();
         style.window_rounding = 0.0;
         style.window_border_size = 0.0;
-        style.colors[ imgui::StyleColor::TitleBg as usize] = [1.0, 1.0, 1.0, 1.0];
+        style.colors[imgui::StyleColor::TitleBg as usize] = [1.0, 1.0, 1.0, 1.0];
 
         let imgui_renderer = Renderer::new(&gl, &mut imgui);
-       
+
         let mut modifiable_string = imgui::ImString::new("");
         let mut mod_color = [0.0, 0.0, 0.0, 0.0];
 
         //let window ;
         event_loop.run(move |event, _, control_flow| {
-
             match event {
-
-                Event::WindowEvent { event: WindowEvent::CloseRequested, .. } => {
+                Event::WindowEvent {
+                    event: WindowEvent::CloseRequested,
+                    ..
+                } => {
                     imgui_renderer.cleanup(&gl);
 
                     *control_flow = ControlFlow::Exit;
-                },
+                }
 
-                Event::NewEvents(_) => {
-                        
-                },
+                Event::NewEvents(_) => {}
 
                 Event::MainEventsCleared => {
-                    platform.prepare_frame(imgui.io_mut(), &windowed_context.window()).expect("Failed to prepare frame");
+                    platform
+                        .prepare_frame(imgui.io_mut(), &windowed_context.window())
+                        .expect("Failed to prepare frame");
                     windowed_context.window().request_redraw();
-                },
+                }
 
                 Event::RedrawRequested(_) => {
-
                     gl.clear(glow::COLOR_BUFFER_BIT);
-
 
                     // other application-specific logic
                     let delta = Instant::now().duration_since(last_frame); //  last_frame.duration_since(  )
-                    imgui.io_mut().update_delta_time( delta );
+                    imgui.io_mut().update_delta_time(delta);
                     last_frame = Instant::now();
 
                     platform.handle_event(imgui.io_mut(), &windowed_context.window(), &event); // step 3
 
                     let ui = imgui.frame();
 
-                    imgui::Window::new( im_str!("Hello window!") )
-                        .size([300.0, windowed_context.window().inner_size().height as f32], imgui::Condition::Always)
-                        .position([0.0,0.0], imgui::Condition::Always)
-                        
-                        .build( &ui, || {
-                        
-                        imgui::Slider::new(im_str!("Slider!"))
-                            .range(0.0 ..= 1.0)
-                            .build(&ui, &mut changeable);
+                    imgui::Window::new(im_str!("Hello window!"))
+                        .size(
+                            [300.0, windowed_context.window().inner_size().height as f32],
+                            imgui::Condition::Always,
+                        )
+                        .position([0.0, 0.0], imgui::Condition::Always)
+                        .build(&ui, || {
+                            imgui::Slider::new(im_str!("Slider!"))
+                                .range(0.0..=1.0)
+                                .build(&ui, &mut changeable);
 
-                        ui.text("text");
-                        imgui::InputText::new(&ui, im_str!("hey there!"), &mut modifiable_string ).resize_buffer(true).build();
-                        imgui::ColorEdit::new( im_str!("color"), &mut mod_color ).hdr(true).build(&ui);
-
-                    });
+                            ui.text("text");
+                            imgui::InputText::new(
+                                &ui,
+                                im_str!("hey there!"),
+                                &mut modifiable_string,
+                            )
+                            .resize_buffer(true)
+                            .build();
+                            imgui::ColorEdit::new(im_str!("color"), &mut mod_color)
+                                .hdr(true)
+                                .build(&ui);
+                        });
 
                     ui.show_demo_window(&mut true);
-
 
                     let draw_data = ui.render();
                     imgui_renderer.render(&gl, &draw_data);
                     windowed_context.swap_buffers().unwrap();
-                    
-
-                },
+                }
                 // other application-specific event handling
                 event => {
-                    platform.handle_event(imgui.io_mut(), &windowed_context.window(), &event); // step 3
+                    platform.handle_event(imgui.io_mut(), &windowed_context.window(), &event);
+                    // step 3
                 }
-            } 
+            }
         });
-        
-
     } // end of unsafe
-
-
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -23,114 +23,110 @@ fn main() {
         context
     };
 
-    unsafe {
-        use glutin::event::{Event, WindowEvent};
-        use glutin::event_loop::ControlFlow;
+    use glutin::event::{Event, WindowEvent};
+    use glutin::event_loop::ControlFlow;
 
-        let mut changeable = 0.01;
-        let mut last_frame = Instant::now();
+    let mut changeable = 0.01;
+    let mut last_frame = Instant::now();
 
-        let scale_factor = windowed_context.window().scale_factor() as f32;
-        let mut imgui = imgui::Context::create();
-        imgui.set_ini_filename(None);
+    let scale_factor = windowed_context.window().scale_factor() as f32;
+    let mut imgui = imgui::Context::create();
+    imgui.set_ini_filename(None);
 
-        let mut platform = WinitPlatform::init(&mut imgui);
-        platform.attach_window(
-            imgui.io_mut(),
-            windowed_context.window(),
-            HiDpiMode::Default,
-        );
+    let mut platform = WinitPlatform::init(&mut imgui);
+    platform.attach_window(
+        imgui.io_mut(),
+        windowed_context.window(),
+        HiDpiMode::Default,
+    );
 
-        let font_size = 13.0 * scale_factor;
-        imgui
-            .fonts()
-            .add_font(&[imgui::FontSource::DefaultFontData {
-                config: Some(imgui::FontConfig {
-                    size_pixels: font_size,
-                    ..imgui::FontConfig::default()
-                }),
-            }]);
+    let font_size = 13.0 * scale_factor;
+    imgui
+        .fonts()
+        .add_font(&[imgui::FontSource::DefaultFontData {
+            config: Some(imgui::FontConfig {
+                size_pixels: font_size,
+                ..imgui::FontConfig::default()
+            }),
+        }]);
 
-        imgui.io_mut().font_global_scale = (1.0 / scale_factor) as f32;
-        let mut style = imgui.style_mut().clone();
-        style.window_rounding = 0.0;
-        style.window_border_size = 0.0;
-        style.colors[imgui::StyleColor::TitleBg as usize] = [1.0, 1.0, 1.0, 1.0];
+    imgui.io_mut().font_global_scale = (1.0 / scale_factor) as f32;
+    let mut style = imgui.style_mut().clone();
+    style.window_rounding = 0.0;
+    style.window_border_size = 0.0;
+    style.colors[imgui::StyleColor::TitleBg as usize] = [1.0, 1.0, 1.0, 1.0];
 
-        let imgui_renderer = Renderer::new(&gl, &mut imgui);
+    let imgui_renderer = Renderer::new(&gl, &mut imgui);
 
-        let mut modifiable_string = imgui::ImString::new("");
-        let mut mod_color = [0.0, 0.0, 0.0, 0.0];
+    let mut modifiable_string = imgui::ImString::new("");
+    let mut mod_color = [0.0, 0.0, 0.0, 0.0];
 
-        //let window ;
-        event_loop.run(move |event, _, control_flow| {
-            match event {
-                Event::WindowEvent {
-                    event: WindowEvent::CloseRequested,
-                    ..
-                } => {
-                    imgui_renderer.cleanup(&gl);
+    //let window ;
+    event_loop.run(move |event, _, control_flow| {
+        match event {
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                ..
+            } => {
+                imgui_renderer.cleanup(&gl);
 
-                    *control_flow = ControlFlow::Exit;
-                }
+                *control_flow = ControlFlow::Exit;
+            }
 
-                Event::NewEvents(_) => {}
+            Event::NewEvents(_) => {}
 
-                Event::MainEventsCleared => {
-                    platform
-                        .prepare_frame(imgui.io_mut(), &windowed_context.window())
-                        .expect("Failed to prepare frame");
-                    windowed_context.window().request_redraw();
-                }
+            Event::MainEventsCleared => {
+                platform
+                    .prepare_frame(imgui.io_mut(), &windowed_context.window())
+                    .expect("Failed to prepare frame");
+                windowed_context.window().request_redraw();
+            }
 
-                Event::RedrawRequested(_) => {
+            Event::RedrawRequested(_) => {
+                unsafe {
                     gl.clear(glow::COLOR_BUFFER_BIT);
+                }
 
-                    // other application-specific logic
-                    let delta = Instant::now().duration_since(last_frame); //  last_frame.duration_since(  )
-                    imgui.io_mut().update_delta_time(delta);
-                    last_frame = Instant::now();
+                // other application-specific logic
+                let delta = Instant::now().duration_since(last_frame); //  last_frame.duration_since(  )
+                imgui.io_mut().update_delta_time(delta);
+                last_frame = Instant::now();
 
-                    platform.handle_event(imgui.io_mut(), &windowed_context.window(), &event); // step 3
+                platform.handle_event(imgui.io_mut(), &windowed_context.window(), &event); // step 3
 
-                    let ui = imgui.frame();
+                let ui = imgui.frame();
 
-                    imgui::Window::new(im_str!("Hello window!"))
-                        .size(
-                            [300.0, windowed_context.window().inner_size().height as f32],
-                            imgui::Condition::Always,
-                        )
-                        .position([0.0, 0.0], imgui::Condition::Always)
-                        .build(&ui, || {
-                            imgui::Slider::new(im_str!("Slider!"))
-                                .range(0.0..=1.0)
-                                .build(&ui, &mut changeable);
+                imgui::Window::new(im_str!("Hello window!"))
+                    .size(
+                        [300.0, windowed_context.window().inner_size().height as f32],
+                        imgui::Condition::Always,
+                    )
+                    .position([0.0, 0.0], imgui::Condition::Always)
+                    .build(&ui, || {
+                        imgui::Slider::new(im_str!("Slider!"))
+                            .range(0.0..=1.0)
+                            .build(&ui, &mut changeable);
 
-                            ui.text("text");
-                            imgui::InputText::new(
-                                &ui,
-                                im_str!("hey there!"),
-                                &mut modifiable_string,
-                            )
+                        ui.text("text");
+                        imgui::InputText::new(&ui, im_str!("hey there!"), &mut modifiable_string)
                             .resize_buffer(true)
                             .build();
-                            imgui::ColorEdit::new(im_str!("color"), &mut mod_color)
-                                .hdr(true)
-                                .build(&ui);
-                        });
+                        imgui::ColorEdit::new(im_str!("color"), &mut mod_color)
+                            .hdr(true)
+                            .build(&ui);
+                    });
 
-                    ui.show_demo_window(&mut true);
+                ui.show_demo_window(&mut true);
 
-                    let draw_data = ui.render();
-                    imgui_renderer.render(&gl, &draw_data);
-                    windowed_context.swap_buffers().unwrap();
-                }
-                // other application-specific event handling
-                event => {
-                    platform.handle_event(imgui.io_mut(), &windowed_context.window(), &event);
-                    // step 3
-                }
+                let draw_data = ui.render();
+                imgui_renderer.render(&gl, &draw_data);
+                windowed_context.swap_buffers().unwrap();
             }
-        });
-    } // end of unsafe
+            // other application-specific event handling
+            event => {
+                platform.handle_event(imgui.io_mut(), &windowed_context.window(), &event);
+                // step 3
+            }
+        }
+    });
 }


### PR DESCRIPTION
Thanks for this! Exciting to have a backend using a library somewhere between the fast developing gfx-rs project and the "maintenance only" glium :partying_face:

I started trying to work out what was involved in implementing the main missing feature (changing cursors), before realizing this was of course handled in `imgui-winit-platform`, and the example was just a missing `platform.prepare_render(...)` call!

I've also:
- moved the big `unsafe { ... }` block to just the methods that require it
- added some comments to help structure the example more clearly
- ran the entire thing through `cargo fmt`